### PR TITLE
Add frontend_before hook

### DIFF
--- a/vault/frontend.php
+++ b/vault/frontend.php
@@ -108,6 +108,9 @@ $phpMussel['FE'] = [
 
 ];
 
+/** Plugin hook: "frontend_before". */
+$phpMussel['Execute_Hook']('frontend_before');
+
 /** Fetch pips data. */
 $phpMussel['Pips_Path'] = $phpMussel['GetAssetPath']('pips.php', true);
 if (!empty($phpMussel['Pips_Path']) && is_readable($phpMussel['Pips_Path'])) {


### PR DESCRIPTION
In order to use frontend feature safely inside my system, I need to replace phpMussel's authentication system with my own. Since plugin hooks are not able to return custom value, I have added two hooks:
- `before_frontend_login` to update `$_POST` data so that phpMussel's authentication system passes.
- `after_frontend_login` to fire my own authentication system.