### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/vault/cache/*
+!/vault/cache/.htaccess
+/vault/config.ini
+/vault/fe_assets/frontend.dat
+/vault/scan_log.txt
+/vault/scan_log_serialized.txt
+/vault/signatures/*
+!/vault/signatures/.htaccess
+!/vault/signatures/switch.dat


### PR DESCRIPTION
For easier development, files that are automatically generated while using the system should be defined in `.gitignore` so that there is no need to revert them before every commit.